### PR TITLE
Updating the `launchpad_register_widget` ID issue

### DIFF
--- a/lib/core/template.php
+++ b/lib/core/template.php
@@ -595,7 +595,7 @@ function launchpad_register_widget() {
 		array(
 			'name' => 'Blog Sidebar',
 			'id' => 'blog_sidebar',
-			'before_widget' => '<section id="flexible-widget">',
+			'before_widget' => '<section class="flexible-widget">',
 			'after_widget' => '</section>',
 			'before_title' => '<h1>',
 			'after_title' => '</h1>',


### PR DESCRIPTION
Edited the `before_widget` to use `class` instead of `id`

close #46