### PR TITLE
Remove WYSIWYG Media Button

### DIFF
--- a/lib/core/metaboxes.php
+++ b/lib/core/metaboxes.php
@@ -406,12 +406,13 @@ function launchpad_render_field_file($field_output_name, $field_output_id = '', 
  */
 function launchpad_render_field_wysiwyg($field_output_name, $field_output_id = '', $args = array(), $val = false) {
 	// Output a WYSIWYG editor.  Just the base code.
+	$field_media_bitton = (!$args['media_button'] && isset($args['media_button']))?false:true;
 	wp_editor(
 			$val, 
 			$field_output_id,
 			array(
 				'wpautop' => true,
-				'media_buttons' => true,
+				'media_buttons' => $field_media_button,
 				'textarea_name' => $field_output_name,
 				'textarea_rows' => 10,
 				'tinymce' => true,


### PR DESCRIPTION
Updated the `launchpad_render_field_wysiwyg` to allow for hiding of the WYSIWYG Media Button.

When setting up your field you can pass the following in the `args`:

```
args = array(
	'type' => 'wysiwyg',
	'media_buttons' => false
)
```